### PR TITLE
update inline autocomplete in declaration 

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -1204,7 +1204,7 @@ export class InlineAutocomplete {
 
     getInlineRenderer(): Ace.AceInline;
 
-    getInlineTooltip(): InlineTooltip;
+    getInlineTooltip(): CommandBarTooltip;
 
     getCompletionProvider(): Ace.CompletionProvider;
 
@@ -1219,7 +1219,7 @@ export class InlineAutocomplete {
     goTo(action: InlineAutocompleteAction): void;
 
     tooltipEnabled: boolean;
-    commands: Record<string, TooltipCommand>
+    commands: Record<string, Ace.Command>
 
     getIndex(): number;
 
@@ -1232,18 +1232,22 @@ export class InlineAutocomplete {
     updateCompletions(options: Ace.CompletionOptions): void;
 }
 
-export class InlineTooltip {
+export class CommandBarTooltip {
     constructor(parentElement: HTMLElement);
 
-    setCommands(commands: Record<string, TooltipCommand>): void;
+    registerCommand(id: string, command: TooltipCommand): void;
 
-    show(editor: Ace.Editor): void;
+    attach(editor: Ace.Editor): void;
 
     updatePosition(): void;
 
-    updateButtons(force?: boolean): void;
+    update(): void;
 
     isShown(): boolean;
+
+    getAlwaysShow(): boolean;
+
+    setAlwaysShow(alwaysShow: boolean): void;
 
     detach(): void;
 


### PR DESCRIPTION
In [this Ace PR](https://github.com/ajaxorg/ace/pull/5149) we changed some of the types used for inline autocomplete. This caused the api docs scripts to fail. This changes the declaration file to match the changes made in the Ace repo. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
