### PR TITLE
opening code source links in the same window

### DIFF
--- a/generateDoc.js
+++ b/generateDoc.js
@@ -1,9 +1,10 @@
 var typedoc = require('typedoc');
 
 async function main() {
-    const app = await typedoc.Application.bootstrapWithPlugins();
-    var gitLink = "https://github.com/ajaxorg/ace/tree/" + process.env.ACE_VERSION + "/{path}#L{line}";
-    app.options.setValue("sourceLinkTemplate", gitLink);
+    const app = await typedoc.Application.bootstrapWithPlugins({
+        sourceLinkExternal: false,
+        sourceLinkTemplate: "https://github.com/ajaxorg/ace/tree/" + process.env.ACE_VERSION + "/{path}#L{line}",
+    });
 
     const projectReflection = await app.convert();
 


### PR DESCRIPTION
## Why
* Prevents, reverse tabnabbing, which is only possible using really old browsers tbh.

## What
* Make our source code links open in the same tab/window.
* I didn't see a better Typedoc option from https://typedoc.org/api/interfaces/Configuration.TypeDocOptions.html
* I think it also should be doable through a custom plugin or a forked theme or through a custom script, but I don't think it's worth the effort and complexity introduced.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
